### PR TITLE
Add support for standard input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 dist
 *.egg-info
 .coverage
+poetry.lock


### PR DESCRIPTION
Fix #5 

Add a new argument that provides an easy way to send information through the command's standard input.